### PR TITLE
feat(integer_range): add distribution types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Genie is an templatable event generator.  It can currently be used to generate p
 
 ## Commands
 
-### generate
+### generate [EVENT] [ARGS...]
 
-The generate command starts up the configured event generators.
+The generate command starts up the configured event generators. An optional event can be specified to limit the generator to a single event.  If an event is not specified, the generator will run all configured events.
 
 #### Options
 
@@ -161,8 +161,10 @@ The integer range resource renders a random value between 2 numbers.  The follow
 | ---- | ----------- | ------- |
 | min | the mininimum number of the range | 0 |
 | max | the maximum number of the range | 10 |
-| step | the number used to increment the value when the range is generated | 1 |
 | pad | left pad `0`'s to the number when it is accessed by the template | 0 |
+| distribution | the distribution of the generated integers (uniform, normal). | uniform |
+| stddev | ***(normal distribution)*** sets the size of a standard deviation for a range that is normally distributed | (max-min)/10 |
+| mean | ***(normal distribution)*** sets the mean for the range that is normally distributed | (max-min)/2 |
 
 ##### IP Address
 
@@ -207,7 +209,7 @@ The UUID resource renders uuid1 or uuid4 formatted unique identifiers.
 
 #### Filters
 
-***Still a work in progress.***
+***Work in progress.***
 
 Filters can be added to variables using the `|` pipe character.
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -9,8 +9,12 @@ events:
     generators: 10
     raw: >
       <<list.left_names>> <<list.right_names>>
+  - name: latency_measurement
+    generators: 1
+    raw: >
+      {"application": "foo", "latency": <<integer_range.latency>>}
   - name: nginx_logs
     generators: 1
     raw: >
       <# $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'; #>
-      <<ipaddr.internal>> - - [<<timestamp.now_common_log>>] "<<list.method>> <<list.path>> HTTP/1.1" <<list.status_code>> <<integer_range.size>> "-" "<<list.user_agent>>" "<<ipaddr.external>>"
+      <<ipaddr.internal>> - - [<<timestamp.now_common_log>>] "<<list.method>> <<list.path>> HTTP/1.1" <<list.status_code>> <<integer_range.bytes_sent>> "-" "<<list.user_agent>>" "<<ipaddr.external>>"

--- a/examples/resources.yaml
+++ b/examples/resources.yaml
@@ -18,6 +18,18 @@ resources:
     size:
       min: 300
       max: 900
+    bytes_sent:
+      min: 100
+      max: 1000
+      distribution: normal
+      stddev: 50
+      mean: 300
+    latency:
+      min: 100
+      max: 2000
+      distribution: normal
+      stddev: 150
+      mean: 400
   random_strings:
     ten:
       size: 10

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/twmb/franz-go v1.15.0
 	github.com/twmb/franz-go/pkg/kadm v1.9.2
 	go.uber.org/zap v1.25.0
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -82,6 +82,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,3 +90,12 @@ func Load(opts *LoadOptions) (*Config, error) {
 
 	return out, nil
 }
+
+func (c *Config) HasEvents() bool {
+	return len(c.Events) > 0
+}
+
+func (c *Config) HasEvent(name string) bool {
+	_, has := c.Events[name]
+	return has
+}

--- a/pkg/resources/config_test.go
+++ b/pkg/resources/config_test.go
@@ -41,10 +41,10 @@ uuids:
 	expected := &Config{
 		IntegerRanges: map[string]integer_range.Config{
 			"range1": {
-				Min:  1,
-				Max:  5,
-				Pad:  3,
-				Step: integer_range.DefaultIntegerRangeStep,
+				Min:          1,
+				Max:          5,
+				Pad:          3,
+				Distribution: integer_range.DefaultIntegerRangeDistribution,
 			},
 		},
 		Lists: map[string]list.Config{
@@ -114,7 +114,6 @@ func TestDefaultedIntegerRange(t *testing.T) {
 	assert.Equal(t, integer_range.DefaultIntegerRangeMax, cfg.Max)
 	assert.Equal(t, integer_range.DefaultIntegerRangeMin, cfg.Min)
 	assert.Equal(t, integer_range.DefaultIntegerRangePad, cfg.Pad)
-	assert.Equal(t, integer_range.DefaultIntegerRangeStep, cfg.Step)
 }
 
 func TestIntegerRange(t *testing.T) {

--- a/pkg/resources/integer_range/config.go
+++ b/pkg/resources/integer_range/config.go
@@ -4,10 +4,12 @@ import "fmt"
 
 // Config is the configuration for the integer_range resource.
 type Config struct {
-	Min  int64  `yaml:"min"`
-	Max  int64  `yaml:"max"`
-	Step int64  `yaml:"step"`
-	Pad  uint32 `yaml:"pad"`
+	Min          int64  `yaml:"min"`
+	Max          int64  `yaml:"max"`
+	Pad          uint32 `yaml:"pad"`
+	Distribution string `yaml:"distribution"`
+	StdDev       *float64
+	Mean         *int64
 }
 
 // validate ensures that the configuration is valid.
@@ -17,6 +19,18 @@ func (i *Config) validate() error {
 		return fmt.Errorf("max (%d) in integer_range must be greater than zero and the minimum value", i.Max)
 	}
 
+	if i.Distribution != "uniform" && i.Distribution != "normal" {
+		return fmt.Errorf("distribution (%s) in integer_range must be either 'uniform' or 'normal'", i.Distribution)
+	}
+
+	if i.StdDev != nil && *i.StdDev > float64(i.Max-i.Min) {
+		return fmt.Errorf("standard deviation (%f) in integer_range must be less than the range (%d)", *i.StdDev, i.Max-i.Min)
+	}
+
+	if i.Mean != nil && (*i.Mean < i.Min || *i.Mean > i.Max) {
+		return fmt.Errorf("mean (%d) in integer_range must be in the range of (%d, %d)", *i.Mean, i.Min, i.Max)
+	}
+
 	return nil
 }
 
@@ -24,10 +38,10 @@ func (i *Config) validate() error {
 func (i *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type ConfigDefaulted Config
 	var defaults = ConfigDefaulted{
-		Min:  DefaultIntegerRangeMin,
-		Max:  DefaultIntegerRangeMax,
-		Step: DefaultIntegerRangeStep,
-		Pad:  DefaultIntegerRangePad,
+		Min:          DefaultIntegerRangeMin,
+		Max:          DefaultIntegerRangeMax,
+		Pad:          DefaultIntegerRangePad,
+		Distribution: DefaultIntegerRangeDistribution,
 	}
 
 	out := defaults

--- a/pkg/resources/integer_range/defaults.go
+++ b/pkg/resources/integer_range/defaults.go
@@ -5,8 +5,12 @@ const (
 	DefaultIntegerRangeMin int64 = 0
 	// DefaultIntegerRangeMax is the default maximum value for the integer_range resource.
 	DefaultIntegerRangeMax int64 = 10
-	// DefaultIntegerRangeStep is the default step value for the integer_range resource.
-	DefaultIntegerRangeStep int64 = 1
 	// DefaultIntegerRangePad is the default pad value for the integer_range resource.
 	DefaultIntegerRangePad uint32 = 0
+	// DefaultIntegerRangeDistribution is the default distribution
+	DefaultIntegerRangeDistribution string = "uniform"
+	// DefaultStandardDeviation is the default standard deviation for the normal distribution
+	DefaultStandardDeviation float64 = 1.0
+	// DefaultMean is the default mean for the normal distribution
+	DefaultMean float64 = 0.0
 )

--- a/pkg/resources/integer_range/integer_range.go
+++ b/pkg/resources/integer_range/integer_range.go
@@ -2,46 +2,79 @@ package integer_range //nolint:revive
 
 import (
 	"fmt"
-	"math/rand"
+	"time"
+
+	"golang.org/x/exp/rand"
 )
 
 // IntegerRange is a resource that generates a random integer between a minimum
 type IntegerRange struct {
-	min   int64
-	max   int64
-	step  int64
-	pad   uint32
-	cache []string
+	min          int64
+	max          int64
+	pad          uint32
+	distribution string
+	stddev       *float64
+	mean         *int64
+	// cache        []string
 }
 
 // New returns a new integer_range resource initialized from the given config.
 func New(cfg Config) *IntegerRange {
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	if cfg.StdDev == nil {
+		cfg.StdDev = new(float64)
+		*cfg.StdDev = float64(cfg.Max-cfg.Min) / 10
+	}
+
+	if cfg.Mean == nil {
+		cfg.Mean = new(int64)
+		*cfg.Mean = (cfg.Max - cfg.Min) / 2
+	}
+
 	return &IntegerRange{
-		min:  cfg.Min,
-		max:  cfg.Max,
-		step: cfg.Step,
-		pad:  cfg.Pad,
+		min:          cfg.Min,
+		max:          cfg.Max,
+		pad:          cfg.Pad,
+		distribution: cfg.Distribution,
+		stddev:       cfg.StdDev,
+		mean:         cfg.Mean,
 	}
 }
 
 // Cache creates a cache of all possible values for this resource.  This is a
 // simple, non-optimal from a memory perspective, but it's a good first step.
-func (i *IntegerRange) Cache() []string {
-	c := make([]string, 0)
-	num := i.min
-	for num <= i.max {
-		padded := fmt.Sprintf("%0*d", i.pad, num)
-		c = append(c, padded)
-		num += i.step
-	}
-	return c
-}
+// func (i *IntegerRange) Cache() []string {
+// 	c := make([]string, 0)
+// 	num := i.min
+// 	for num <= i.max {
+// 		padded := fmt.Sprintf("%0*d", i.pad, num)
+// 		c = append(c, padded)
+// 		num += i.step
+// 	}
+// 	return c
+// }
 
 // Get implements the Resource interface.
 func (i *IntegerRange) Get() string {
-	if i.cache == nil {
-		i.cache = i.Cache()
+	var integer int64
+
+	switch i.distribution {
+	case "normal":
+		// TODO: make stddev and mean configurable.  The mean should be allowed to shift.
+		// we will also need to floor the i.min and ceil the i.max
+		// mean := float64((i.max - i.min) / 2)
+		// stddev := float64((i.max - i.min) / 10)
+
+		integer = int64(rand.NormFloat64()*(*i.stddev) + float64(*i.mean))
+		if integer < i.min {
+			integer = i.min
+		} else if integer > i.max {
+			integer = i.max
+		}
+	default:
+		integer = int64(rand.Int63n(i.max-i.min) + i.min)
 	}
 
-	return i.cache[rand.Intn(len(i.cache))] //nolint:gosec
+	return fmt.Sprintf("%0*d", i.pad, integer)
 }


### PR DESCRIPTION
Adds the distribution settings to the integer range resource.  By default the range still returns random numbers with a uniform distribution, but now the option exists to return integers in a normal distribution.  The mean and the size of the standard deviation can be set in order to manipulate range.  I'm currently utilizing the rand package in experimental and it appears to work well.  With ~1 million measurements output from the `latency_measurement` example event which is configured:

```yaml
latency:
      min: 100
      max: 2000
      distribution: normal
      stddev: 150
      mean: 400
```

The distribution looks like:

<img width="476" alt="Screenshot 2024-05-08 at 10 35 14 AM" src="https://github.com/strataviz/genie/assets/47508711/3fd8654d-417d-4ff4-a934-610a75211115">



Additionally, while I was in there I added the ability to limit to a specific event on the command line, it was something that I had wanted to add, but just never did it.  Seemed like a good time to add it.