### PR TITLE
feat(float_range): add float_range resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ vendor/
 
 *_save/
 
+tmp/
+.venv/
+
 # Don't store test certs
 tests/integration/nginx/conf/ssl/ca.*
 tests/integration/nginx/conf/ssl/server.*

--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ Expressions can be rendered using the delimiters `<<` and `>>`, with the variabl
 
 #### Resources
 
+##### Float Range
+
+The float range resource renders random floats between two values.  The following configuration values are supported:
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| min | The minimum number of the range. In the case of normalized and exponential distributions, it acts as a floor and clamps any generated value less than the minimum. | 0.0 |
+| max | The maximum number of the range.  Like minimum, for normalized and exponential distributions, it clamps any generated value greater than the maximum. | 10.0 |
+| distribution | The distribution of the generated numbers.  This can be `uniform`, `exponential`, and `normal`. | uniform |
+| stddev | When distribution is set to normal, this represents the standard deviation. | (max-min)/8 |
+| mean | When distribution is set to normal, this represents the mean of the values generated. | (max-min/2) |
+| rate | When distribution is set to exponential, this represents the rate of occurrences in a given time interval | 1.0 |
+| format | The expected format for the string representation of the floating point number.  Supports: <ul><li>`none`: no exponent</li><li>`decimal`: decimal representation 'e'</li><li>`decimal_capitalize`: decimal representation 'E'</li><li>`large`: 'e' for large exponents</li><li>`large_capitalize`: 'E' for large exponents</li><li>`binary`: a binary exponent</li><li>`hex`: hexidecimal fraction and binary exponent</li></ul> | none |
+| precision | The number of digits (excuding the exponent) that will be printed | 5 |  
+
+
 ##### Integer Range
 
 The integer range resource renders a random value between 2 numbers.  The following configuration values are supported:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -18,3 +18,11 @@ events:
     raw: >
       <# $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'; #>
       <<ipaddr.internal>> - - [<<timestamp.now_common_log>>] "<<list.method>> <<list.path>> HTTP/1.1" <<list.status_code>> <<integer_range.bytes_sent>> "-" "<<list.user_agent>>" "<<ipaddr.external>>"
+  - name: float_range_exp
+    generators: 1
+    raw: >
+      {"application": "foo", "value": <<float_range.value_exp>>}
+  - name: float_range_norm
+    generators: 1
+    raw: >
+      {"application": "foo", "value": <<float_range.value_norm_formatted>>}

--- a/examples/resources.yaml
+++ b/examples/resources.yaml
@@ -30,6 +30,50 @@ resources:
       distribution: normal
       stddev: 150
       mean: 400
+    # TODO: move to a counter resource
+    prom_gc_count:
+      min: 1
+      max: 10
+  float_ranges:
+    value_exp:
+      min: 0.00
+      max: 10000.0
+      distribution: exponential
+      rate: 1.25
+    value_norm:
+      min: 0.00
+      max: 10.0
+      distribution: normal
+      stddev: 1.0
+      mean: 5.0
+    value_norm_formatted:
+      min: 0.00
+      max: 10000000.0
+      distribution: normal
+      stddev: 10000.0
+      mean: 500000.0
+      format: "decimal"
+      precision: 5
+    go_gc_duration_seconds_0:
+      min: 2.00e-05
+      distribution: exponential
+      rate: 2.5
+    go_gc_duration_seconds_0_25:
+      min: 7.00e-05
+      distribution: exponential
+      rate: 2.5
+    go_gc_duration_seconds_0_5:
+      min: 1.30e-04
+      distribution: exponential
+      rate: 2.5
+    go_gc_duration_seconds_0_75:
+      min: 1.75e-04
+      distribution: exponential
+      rate: 2.5
+    go_gc_duration_seconds_1:
+      min: 2.00e-04
+      distribution: exponential
+      rate: 2.5
   random_strings:
     ten:
       size: 10

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ import (
 	"stvz.io/genie/pkg/cmd"
 )
 
+const (
+	DefaultMetricsPort = 9090
+)
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGSTOP)
 	defer cancel()
@@ -56,7 +60,7 @@ func main() {
 	go func() {
 		defer obs.Done()
 		err := metrics.Start(strata.ServerOpts{
-			Port: 9090,
+			Port: DefaultMetricsPort,
 		})
 		if err != nil && err != http.ErrServerClosed {
 			logger.Error(err, "metrics server start failed")

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"stvz.io/genie/pkg/resources/float_range"
 	"stvz.io/genie/pkg/resources/integer_range"
 	"stvz.io/genie/pkg/resources/ipaddr"
 	"stvz.io/genie/pkg/resources/list"
@@ -13,6 +14,7 @@ import (
 // top-level configuration for the resources block.
 type Config struct {
 	IntegerRanges map[string]integer_range.Config `yaml:"integer_ranges"`
+	FloatRanges   map[string]float_range.Config   `yaml:"float_ranges"`
 	Lists         map[string]list.Config          `yaml:"lists"`
 	RandomStrings map[string]random_string.Config `yaml:"random_strings"`
 	Timestamps    map[string]timestamp.Config     `yaml:"timestamps"`

--- a/pkg/resources/float_range/config.go
+++ b/pkg/resources/float_range/config.go
@@ -1,0 +1,97 @@
+package float_range //nolint:revive
+
+import "fmt"
+
+// Config is the configuration for the float_range resource.
+type Config struct {
+	Min          float64  `yaml:"min"`
+	Max          float64  `yaml:"max"`
+	Distribution string   `yaml:"distribution"`
+	StdDev       *float64 `yaml:"stddev"`
+	Mean         *float64 `yaml:"mean"`
+	Rate         float64  `yaml:"rate"`
+	Format       string   `yaml:"format"`
+	Precision    int      `yaml:"precision"`
+}
+
+func (i *Config) validateDistribution(d string) error {
+	switch d {
+	case "uniform", "normal", "exp", "exponential":
+		return nil
+	default:
+		return fmt.Errorf("distribution (%s) in float_range is unknown", d)
+	}
+}
+
+func (i *Config) validateFormat(f string) error {
+	switch f {
+	case "binary", "decimal", "decimal_capitalize", "none", "large", "large_capitalize", "hex", "hex_capitalize":
+		return nil
+	default:
+		return fmt.Errorf("format (%s) in float_range is unknown", f)
+	}
+}
+
+// validate ensures that the configuration is valid.
+func (i *Config) validate() error {
+	// Fix me now that we allow negative values
+	if i.Max <= i.Min {
+		return fmt.Errorf("max (%f) in float_range must be greater than the minimum value", i.Max)
+	}
+
+	if err := i.validateDistribution(i.Distribution); err != nil {
+		return err
+	}
+
+	if err := i.validateFormat(i.Format); err != nil {
+		return err
+	}
+
+	if i.StdDev != nil && *i.StdDev > float64(i.Max-i.Min) {
+		return fmt.Errorf("standard deviation (%f) in float_range must be less than the range (%f)", *i.StdDev, i.Max-i.Min)
+	}
+
+	if i.Mean != nil && (*i.Mean < i.Min || *i.Mean > i.Max) {
+		return fmt.Errorf("mean (%f) in float_range must be in the range of (%f, %f)", *i.Mean, i.Min, i.Max)
+	}
+
+	return nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for defaulting the float_range
+func (i *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type ConfigDefaulted Config
+	var defaults = ConfigDefaulted{
+		Min:          DefaultFloatRangeMin,
+		Max:          DefaultFloatRangeMax,
+		Distribution: DefaultFloatRangeDistribution,
+		Rate:         DefaultFloatRangeRate,
+		Format:       DefaultFloatRangeFormat,
+		Precision:    DefaultFloatRangePrecision,
+	}
+
+	out := defaults
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+
+	tmpl := Config(out)
+
+	// Set the variable attributes if they are nil
+	if tmpl.StdDev == nil {
+		tmpl.StdDev = new(float64)
+		*tmpl.StdDev = float64(tmpl.Max-tmpl.Min) / 8
+	}
+
+	if tmpl.Mean == nil {
+		tmpl.Mean = new(float64)
+		*tmpl.Mean = (tmpl.Max - tmpl.Min) / 2
+	}
+
+	if err := tmpl.validate(); err != nil {
+		return err
+	}
+
+	*i = tmpl
+	return nil
+}

--- a/pkg/resources/float_range/convert.go
+++ b/pkg/resources/float_range/convert.go
@@ -1,0 +1,22 @@
+package float_range
+
+func convertFormat(format string) byte {
+	switch format {
+	case "binary":
+		return 'b'
+	case "decimal":
+		return 'e'
+	case "decimal_capitalize":
+		return 'E'
+	case "large":
+		return 'g'
+	case "large_capitalize":
+		return 'G'
+	case "hex":
+		return 'x'
+	case "hex_capitalize":
+		return 'X'
+	default:
+		return 'f'
+	}
+}

--- a/pkg/resources/float_range/defaults.go
+++ b/pkg/resources/float_range/defaults.go
@@ -1,0 +1,22 @@
+package float_range //nolint:revive
+
+// TODO: add precision to the float_range resource
+
+const (
+	// DefaultFloatRangeMin is the default minimum value for the integer_range resource.
+	DefaultFloatRangeMin float64 = 0.0
+	// DefaultFloatRangeMax is the default maximum value for the integer_range resource.
+	DefaultFloatRangeMax float64 = 10.0
+	// DefaultFloatRangeDistribution is the default distribution
+	DefaultFloatRangeDistribution string = "uniform"
+	// DefaultFloatRangeStandardDeviation is the default standard deviation for the normal distribution
+	DefaultFloatRangeStandardDeviation float64 = 1.0
+	// DefaultFloatRangeMean is the default mean for the normal distribution
+	DefaultFloatRangeMean float64 = 0.0
+	// DefaultFloatRangeRate is the default rate of occurences in an interval for the exponential distribution
+	DefaultFloatRangeRate float64 = 1.0
+	// DefaultFloatRangeFormat is the default format for the float_range resource
+	DefaultFloatRangeFormat string = "none"
+	// DefaultFloatRangePrecision is the default precision for the float_range resource
+	DefaultFloatRangePrecision int = -1
+)

--- a/pkg/resources/float_range/float_range.go
+++ b/pkg/resources/float_range/float_range.go
@@ -1,0 +1,58 @@
+package float_range //nolint:revive
+
+import (
+	"strconv"
+	"time"
+
+	"golang.org/x/exp/rand"
+)
+
+// FloatRange is a resource that generates a random float between a minimum
+type FloatRange struct {
+	min          float64
+	max          float64
+	distribution string
+	stddev       *float64
+	mean         *float64
+	rate         float64
+	format       string
+	precision    int
+}
+
+// New returns a new float_range resource initialized from the given config.
+func New(cfg Config) *FloatRange {
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	return &FloatRange{
+		min:          cfg.Min,
+		max:          cfg.Max,
+		distribution: cfg.Distribution,
+		stddev:       cfg.StdDev,
+		mean:         cfg.Mean,
+		rate:         cfg.Rate,
+		format:       cfg.Format,
+		precision:    cfg.Precision,
+	}
+}
+
+// Get implements the Resource interface.
+func (i *FloatRange) Get() string {
+	var float float64
+
+	switch i.distribution {
+	case "normal":
+		float = rand.NormFloat64()*(*i.stddev) + *i.mean
+	case "exp", "exponential":
+		float = rand.ExpFloat64()/i.rate + i.min
+	default:
+		float = rand.Float64()*(i.max-i.min) + i.min
+	}
+
+	if float < i.min {
+		float = i.min
+	} else if float > i.max {
+		float = i.max
+	}
+
+	return strconv.FormatFloat(float, convertFormat(i.format), i.precision, 64)
+}

--- a/pkg/resources/integer_range/config.go
+++ b/pkg/resources/integer_range/config.go
@@ -54,6 +54,16 @@ func (i *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	if tmpl.StdDev == nil {
+		tmpl.StdDev = new(float64)
+		*tmpl.StdDev = float64(tmpl.Max-tmpl.Min) / 8
+	}
+
+	if tmpl.Mean == nil {
+		tmpl.Mean = new(int64)
+		*tmpl.Mean = (tmpl.Max - tmpl.Min) / 2
+	}
+
 	*i = tmpl
 	return nil
 }

--- a/pkg/resources/integer_range/integer_range.go
+++ b/pkg/resources/integer_range/integer_range.go
@@ -22,16 +22,6 @@ type IntegerRange struct {
 func New(cfg Config) *IntegerRange {
 	rand.Seed(uint64(time.Now().UnixNano()))
 
-	if cfg.StdDev == nil {
-		cfg.StdDev = new(float64)
-		*cfg.StdDev = float64(cfg.Max-cfg.Min) / 10
-	}
-
-	if cfg.Mean == nil {
-		cfg.Mean = new(int64)
-		*cfg.Mean = (cfg.Max - cfg.Min) / 2
-	}
-
 	return &IntegerRange{
 		min:          cfg.Min,
 		max:          cfg.Max,
@@ -76,5 +66,7 @@ func (i *IntegerRange) Get() string {
 		integer = int64(rand.Int63n(i.max-i.min) + i.min)
 	}
 
+	// TODO: Move this to strconv and then move padding to a filter and out of the resource.
+	// i.e. <<integer_range.item|pad(5)>>
 	return fmt.Sprintf("%0*d", i.pad, integer)
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"stvz.io/genie/pkg/resources/float_range"
 	"stvz.io/genie/pkg/resources/integer_range"
 	"stvz.io/genie/pkg/resources/ipaddr"
 	"stvz.io/genie/pkg/resources/list"
@@ -18,6 +19,7 @@ type Resource interface {
 type Resources struct {
 	Lists         map[string]Resource
 	IntegerRanges map[string]Resource
+	FloatRanges   map[string]Resource
 	RandomStrings map[string]Resource
 	UUIDs         map[string]Resource
 	Timestamps    map[string]Resource
@@ -29,6 +31,7 @@ type Resources struct {
 func New(block Config) *Resources {
 	return &Resources{
 		IntegerRanges: parseIntegerRanges(block),
+		FloatRanges:   parseFloatRanges(block),
 		RandomStrings: parseRandomStrings(block),
 		Lists:         parseLists(block),
 		Timestamps:    parseTimestamps(block),
@@ -43,6 +46,17 @@ func parseIntegerRanges(res Config) map[string]Resource {
 
 	for k, v := range res.IntegerRanges {
 		out[k] = integer_range.New(v)
+	}
+
+	return out
+}
+
+// parseFloatRanges parses a map of float ranges into a map of resources.
+func parseFloatRanges(res Config) map[string]Resource {
+	out := make(map[string]Resource)
+
+	for k, v := range res.FloatRanges {
+		out[k] = float_range.New(v)
 	}
 
 	return out
@@ -111,6 +125,8 @@ func (r *Resources) Get(rtype string, name string) (Resource, error) {
 	switch rtype {
 	case "list":
 		return r.GetList(name)
+	case "float_range":
+		return r.GetFloatRange(name)
 	case "integer_range":
 		return r.GetIntegerRange(name)
 	case "random_string":
@@ -140,6 +156,15 @@ func (r *Resources) GetList(name string) (Resource, error) {
 // GetIntegerRange returns an integer range resource by name.
 func (r *Resources) GetIntegerRange(name string) (Resource, error) {
 	if resource, ok := r.IntegerRanges[name]; ok {
+		return resource, nil
+	}
+
+	return nil, NotFoundError
+}
+
+// GetFloatRange returns a float range resource by name.
+func (r *Resources) GetFloatRange(name string) (Resource, error) {
+	if resource, ok := r.FloatRanges[name]; ok {
 		return resource, nil
 	}
 

--- a/pkg/template/lexer_test.go
+++ b/pkg/template/lexer_test.go
@@ -32,6 +32,11 @@ func TestScan(t *testing.T) {
 			NewToken(TokenPeriod, "."),
 			NewToken(TokenIdentifier, "name"),
 		}},
+		{`<< float_range.name >>`, []Token{
+			NewToken(TokenResource, "float_range"),
+			NewToken(TokenPeriod, "."),
+			NewToken(TokenIdentifier, "name"),
+		}},
 		{`<< random_string.name >>`, []Token{
 			NewToken(TokenResource, "random_string"),
 			NewToken(TokenPeriod, "."),

--- a/pkg/template/token.go
+++ b/pkg/template/token.go
@@ -1,6 +1,7 @@
 package template
 
 var builtins = map[string]TokenType{
+	"float_range":   TokenResource,
 	"integer_range": TokenResource,
 	"list":          TokenResource,
 	"random_string": TokenResource,


### PR DESCRIPTION
Adds a new float_range resource.  I may revisit this later and merge both the integer and float ranges into a number range.  For now it made sense to split it off since there were significant differences between the way the two are managed.  That being said, a number range that is based off of the float resource and just casts to an integer would add additional features. Like the integer range, float ranges support the uniform and normal distributions, but also support an exponential distribution.  Formatting is also supported.

I've made a note on the integer range to remove padding from the resource and create a filter for it.  Once that's done, I'll look more closely at merging all the number resources.